### PR TITLE
Fixed error on initial configuration if templates folder doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "idean-styleguide",
+  "version": "1.0.0",
+  "description": "Idean Styleguide",
+  "main": "build.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ideanux/idean-styleguide.git"
+  },
+  "author": "Idean",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ideanux/idean-styleguide/issues"
+  },
+  "homepage": "https://github.com/ideanux/idean-styleguide#readme"
+}

--- a/styleguide/Configurator.js
+++ b/styleguide/Configurator.js
@@ -162,6 +162,7 @@ Configurator.prototype.validateCssCompiler = function(text) {
  */
 Configurator.prototype.validateTemplatePath = function(text) {
 	var pass = true;
+	var createDirectory = false;
 	text = text.replace("\r\n", "").replace("\n","").trim();
 	
 	if(!text) {
@@ -172,11 +173,17 @@ Configurator.prototype.validateTemplatePath = function(text) {
 		var stats = fs.lstatSync(text);
 		if (stats.isDirectory()) {
 			this.templatePath = text;
-		} else {
-			pass = false;
 		}
 	} catch (e) {
-		pass = false;
+		createDirectory = true;
+	}
+	
+	if(createDirectory){
+		try {
+			fs.mkdirSync(text);
+		} catch(e) {
+			throw e;
+		}	
 	}
 	
 	return pass;


### PR DESCRIPTION
The template path given will be created if possible, otherwise it will throw an exception.
